### PR TITLE
Automate the public Crest roadmap sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,10 @@ Use [r/CrestBrowser](https://www.reddit.com/r/CrestBrowser) to discuss early
 ideas, user questions, and compatibility experiences before they become
 actionable engineering work. Use GitHub Issues for reproducible bugs and
 concrete outcomes. The public
-[Crest 0.5 project](https://github.com/users/pauljoda/projects/3) and milestones
-summarize planned release work without exposing private planning details.
+[Crest Roadmap project](https://github.com/users/pauljoda/projects/3) and
+release milestones summarize planned work without exposing private planning
+details. The one-way mapping is documented in
+[`Documentation/PlanningSync.md`](Documentation/PlanningSync.md).
 
 See [SUPPORT.md](SUPPORT.md) for reporting routes and
 [GOVERNANCE.md](GOVERNANCE.md) for the current ownership and decision model.

--- a/Documentation/PlanningSync.md
+++ b/Documentation/PlanningSync.md
@@ -1,0 +1,71 @@
+# Public planning sync
+
+Crest's public GitHub planning is a one-way view of active release work in
+Linear. Linear remains the working source; GitHub Issues, milestones, the
+roadmap project, and `Documentation/ROADMAP.md` present the useful public
+outcomes.
+
+## Project discovery
+
+An open Linear project enters the public view when it has the `Crest` project
+label. Release projects use a `Crest X.Y` or `Crest X.Y.Z` name and map to the
+matching GitHub milestone. Milestones are ordered by version, so the earliest
+active release remains first when later releases are added.
+
+A Linear project already linked to an open GitHub milestone receives one final
+sync even after the Linear project is completed. Closing the GitHub milestone
+remains part of the release process rather than an automatic consequence of a
+planning status change.
+
+## Issue mapping
+
+Every synced GitHub issue carries a hidden `crest-linear-sync` marker containing
+its Linear issue identifier and project identifier. The marker is the durable
+identity; titles can change without creating duplicate issues.
+
+| Linear status type | GitHub issue | Project status |
+| --- | --- | --- |
+| Backlog or unstarted | Open | Backlog |
+| Started | Open | In progress |
+| Completed | Closed as completed | Done |
+| Canceled or duplicate | Closed as not planned | Done |
+
+The `roadmap` label adds an issue to the shared Crest Roadmap project. Platform
+and feature labels are derived from the user-facing scope and existing GitHub
+labels. The sync preserves unrelated labels, discussion, and manually added
+context.
+
+## Public writing boundary
+
+GitHub copy summarizes the user problem, intended outcome, and important
+product boundaries in plain language. It does not copy private Linear text
+verbatim. Machine paths, branch names, private links, logs, screenshots,
+credentials, customer information, internal handoff notes, and implementation
+instructions stay out of the public issue.
+
+Issue text changes only when the public outcome changes materially. Status-only
+updates should not rewrite otherwise useful discussion.
+
+## Completion evidence
+
+A completed issue links a commit or merged pull request only when there is
+direct evidence: the Linear identifier appears in the commit or pull request,
+Linear links the change, or the diff unambiguously implements the exact public
+outcome. The sync never guesses from dates or similar wording. If evidence is
+not available, the issue can close without attribution and gain the link on a
+later run.
+
+Commit identifiers are stored in the issue's sync marker. The generated
+roadmap displays those links beside completed work.
+
+## Roadmap and release notes
+
+`Scripts/render-roadmap.py --write` rebuilds only the marked section of the
+roadmap from open GitHub milestones and `roadmap` issues. Manually maintained
+release gates and platform notes remain outside the generated markers.
+
+The same milestone and completion metadata form the release-note handoff. When
+a release is approved, release automation can query the closed issues in that
+milestone, include their public titles and verified commit links, and combine
+them with commit-derived notes. This keeps release copy grounded in delivered
+work without making Linear or private planning data part of a public build.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -10,6 +10,8 @@ engineering contracts needed to build and maintain it.
   synchronization, and the native/WebKit boundary.
 - [Roadmap](ROADMAP.md) — current public release outcomes and outstanding
   platform gates.
+- [Public planning sync](PlanningSync.md) — the one-way Linear-to-GitHub
+  mapping for release projects, issues, completion evidence, and the roadmap.
 - [Repository guardrails](RepositoryGuardrails.md) — source layout, validation,
   dependency, and public-tree contracts.
 - [Distribution](Distribution.md) — stable and rolling channels, signing,

--- a/Documentation/ROADMAP.md
+++ b/Documentation/ROADMAP.md
@@ -2,24 +2,38 @@
 
 This file summarizes public release outcomes and work that is still outstanding
 or intentionally deferred. The live
-[Crest 0.5 project](https://github.com/users/pauljoda/projects/3) shows status;
-the matching [0.5 milestone](https://github.com/pauljoda/Crest/milestone/1)
-holds the actionable issue descriptions.
+[Crest Roadmap project](https://github.com/users/pauljoda/projects/3) shows
+status; release milestones hold the actionable issue descriptions.
 
-## Crest 0.5
+<!-- crest-roadmap-sync:start -->
+## Active releases
 
-- [Global sidebar widgets](https://github.com/pauljoda/Crest/issues/4) for
-  update availability and active media sessions.
-- [Website notifications](https://github.com/pauljoda/Crest/issues/5) with
-  explicit per-site and per-Space controls.
-- [Picture-in-picture](https://github.com/pauljoda/Crest/issues/6), including an
-  optional automatic mode when leaving a playing video tab.
-- [An About section](https://github.com/pauljoda/Crest/issues/7) for build,
-  update, license, and community information.
-- [An adaptive full mobile sidebar](https://github.com/pauljoda/Crest/issues/8)
-  for iPad, multitasking, and wider iPhone layouts.
-- [Native emoji picking](https://github.com/pauljoda/Crest/issues/9) for icon
-  customization across Apple platforms.
+Release milestones are shown from earliest to latest. The project board holds
+the live status for each issue.
+
+### [0.5](https://github.com/pauljoda/Crest/milestone/1)
+
+#### Planned and in progress
+
+- [ ] [Add global sidebar widgets for updates and media](https://github.com/pauljoda/Crest/issues/4)
+- [ ] [Support video picture-in-picture and optional automatic PiP](https://github.com/pauljoda/Crest/issues/6)
+- [ ] [Add an About section for build, updates, and community links](https://github.com/pauljoda/Crest/issues/7)
+- [ ] [Make the full sidebar adaptive across iPad and wider iPhone layouts](https://github.com/pauljoda/Crest/issues/8)
+- [ ] [Add native emoji picking to icon customization](https://github.com/pauljoda/Crest/issues/9)
+- [ ] [Import passwords from standard browser exports](https://github.com/pauljoda/Crest/issues/16)
+- [ ] [Refine split-view groups with editable names, icons, and tint](https://github.com/pauljoda/Crest/issues/17)
+- [ ] [Improve download access and archive-menu behavior](https://github.com/pauljoda/Crest/issues/18)
+- [ ] [Offer optional search suggestions in the command palette](https://github.com/pauljoda/Crest/issues/19)
+- [ ] [Add a default page zoom setting](https://github.com/pauljoda/Crest/issues/20)
+- [ ] [Keep the iPad layout stable with the floating keyboard](https://github.com/pauljoda/Crest/issues/21)
+
+#### Completed
+
+- [x] [Add website notification support with clear per-Space controls](https://github.com/pauljoda/Crest/issues/5) — [`116cecc8`](https://github.com/pauljoda/Crest/commit/116cecc871a8cd369ce567e93535fa5ff1c0ca01)
+- [x] [Prevent synced pinned and saved tabs from disappearing](https://github.com/pauljoda/Crest/issues/14) — [`ba775bfe`](https://github.com/pauljoda/Crest/commit/ba775bfe1819db9b2d0792f8f3687309078d8a5e)
+- [x] [Support website location permissions](https://github.com/pauljoda/Crest/issues/15) — [`116cecc8`](https://github.com/pauljoda/Crest/commit/116cecc871a8cd369ce567e93535fa5ff1c0ca01), [`986bee77`](https://github.com/pauljoda/Crest/commit/986bee77f3e4331c5ab0f619a225a6a8aa97d1b2)
+
+<!-- crest-roadmap-sync:end -->
 
 These describe intended user outcomes rather than fixed implementation
 promises. Scope may change when WebKit capability, accessibility, or physical

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     ·
     <a href="https://github.com/pauljoda/Crest/releases/latest">Download for Mac</a>
     ·
-    <a href="https://github.com/users/pauljoda/projects/3">0.5 roadmap</a>
+    <a href="https://github.com/users/pauljoda/projects/3">Roadmap</a>
     ·
     <a href="https://www.reddit.com/r/CrestBrowser">Community</a>
   </p>
@@ -103,7 +103,7 @@ Behavior changes should begin with a focused regression test, followed by the af
 
 ## Project status
 
-Crest is under active development. The current implementation includes the core browsing, Space isolation, native platform chrome, credentials, data portability, synchronization foundations, Quick Window, Peek, and privacy features described above. The [Crest 0.5 project](https://github.com/users/pauljoda/projects/3) is the public release view; approval-gated and physical-device work remains documented in the [roadmap](Documentation/ROADMAP.md).
+Crest is under active development. The current implementation includes the core browsing, Space isolation, native platform chrome, credentials, data portability, synchronization foundations, Quick Window, Peek, and privacy features described above. The [Crest Roadmap project](https://github.com/users/pauljoda/projects/3) is the public release view; approval-gated and physical-device work remains documented in the [roadmap](Documentation/ROADMAP.md).
 
 ## Community and support
 

--- a/Scripts/Tests/test_render_roadmap.py
+++ b/Scripts/Tests/test_render_roadmap.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Regression coverage for the generated public roadmap section."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPOSITORY_ROOT / "Scripts" / "render-roadmap.py"
+
+
+def load_renderer():
+    spec = importlib.util.spec_from_file_location("crest_roadmap_renderer", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load Scripts/render-roadmap.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RenderRoadmapTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.renderer = load_renderer()
+
+    def test_release_order_status_and_commit_evidence(self) -> None:
+        snapshot = {
+            "milestones": [
+                {"number": 3, "title": "0.6", "state": "open"},
+                {"number": 1, "title": "0.5", "state": "open"},
+                {"number": 4, "title": "0.4", "state": "closed"},
+            ],
+            "issues": [
+                {
+                    "number": 20,
+                    "title": "Later work",
+                    "url": "https://github.com/pauljoda/Crest/issues/20",
+                    "state": "OPEN",
+                    "labels": [{"name": "roadmap"}],
+                    "milestone": {"title": "0.6"},
+                    "body": "<!-- crest-linear-sync\nissue: APP-300\n-->",
+                },
+                {
+                    "number": 12,
+                    "title": "Delivered work",
+                    "url": "https://github.com/pauljoda/Crest/issues/12",
+                    "state": "CLOSED",
+                    "labels": [{"name": "roadmap"}],
+                    "milestone": {"title": "0.5"},
+                    "body": "<!-- crest-linear-sync\nissue: APP-250\ncommit: abcdef1234567890\n-->",
+                },
+                {
+                    "number": 11,
+                    "title": "Current work",
+                    "url": "https://github.com/pauljoda/Crest/issues/11",
+                    "state": "OPEN",
+                    "labels": [{"name": "roadmap"}],
+                    "milestone": {"title": "0.5"},
+                    "body": "",
+                },
+            ],
+        }
+
+        rendered = self.renderer.render_managed_section(snapshot, "pauljoda/Crest")
+
+        self.assertLess(rendered.index("### [0.5]"), rendered.index("### [0.6]"))
+        self.assertIn("- [ ] [Current work]", rendered)
+        self.assertIn("- [x] [Delivered work]", rendered)
+        self.assertIn("/commit/abcdef1234567890", rendered)
+        self.assertNotIn("### [0.4]", rendered)
+
+    def test_replacement_preserves_manually_maintained_sections(self) -> None:
+        document = """# Roadmap
+
+Intro.
+
+<!-- crest-roadmap-sync:start -->
+old generated content
+<!-- crest-roadmap-sync:end -->
+
+## Release gates
+
+- Keep this text.
+"""
+        managed = """<!-- crest-roadmap-sync:start -->
+new generated content
+<!-- crest-roadmap-sync:end -->"""
+
+        rendered = self.renderer.replace_managed_section(document, managed)
+
+        self.assertIn("new generated content", rendered)
+        self.assertNotIn("old generated content", rendered)
+        self.assertIn("## Release gates\n\n- Keep this text.", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/render-roadmap.py
+++ b/Scripts/render-roadmap.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Render the managed section of Documentation/ROADMAP.md from GitHub issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any, Optional
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ROADMAP = REPOSITORY_ROOT / "Documentation" / "ROADMAP.md"
+START_MARKER = "<!-- crest-roadmap-sync:start -->"
+END_MARKER = "<!-- crest-roadmap-sync:end -->"
+COMMIT_LINE = re.compile(r"^commits?:\s*(?P<commits>[0-9a-fA-F, ]+)$", re.MULTILINE)
+VERSION = re.compile(r"^v?(?P<version>\d+(?:\.\d+){1,2})(?:\b|$)")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render Crest's public roadmap from roadmap-labelled GitHub issues."
+    )
+    parser.add_argument("--repository", default="pauljoda/Crest")
+    parser.add_argument("--input", type=Path, help="Read a saved JSON snapshot instead of GitHub.")
+    parser.add_argument("--roadmap", type=Path, default=DEFAULT_ROADMAP)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="Update the roadmap in place.")
+    mode.add_argument("--check", action="store_true", help="Fail when the roadmap is stale.")
+    return parser.parse_args()
+
+
+def run_json(arguments: list[str]) -> Any:
+    result = subprocess.run(
+        arguments,
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"{' '.join(arguments)} failed: {detail}")
+    return json.loads(result.stdout)
+
+
+def load_snapshot(
+    path: Optional[Path], repository: str
+) -> dict[str, list[dict[str, Any]]]:
+    if path is not None:
+        with path.open(encoding="utf-8") as stream:
+            snapshot = json.load(stream)
+        return {
+            "issues": list(snapshot.get("issues", [])),
+            "milestones": list(snapshot.get("milestones", [])),
+        }
+
+    issues = run_json(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repository,
+            "--state",
+            "all",
+            "--limit",
+            "1000",
+            "--label",
+            "roadmap",
+            "--json",
+            "number,title,url,state,labels,milestone,body,closedAt",
+        ]
+    )
+    milestone_pages = run_json(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repository}/milestones?state=all&per_page=100",
+        ]
+    )
+    milestones = [milestone for page in milestone_pages for milestone in page]
+    return {"issues": issues, "milestones": milestones}
+
+
+def label_names(issue: dict[str, Any]) -> set[str]:
+    return {
+        label["name"] if isinstance(label, dict) else str(label)
+        for label in issue.get("labels", [])
+    }
+
+
+def release_sort_key(title: str) -> tuple[int, tuple[int, ...], str]:
+    match = VERSION.match(title)
+    if match is None:
+        return (1, (), title.casefold())
+    parts = tuple(int(part) for part in match.group("version").split("."))
+    return (0, parts, title.casefold())
+
+
+def completion_commits(issue: dict[str, Any]) -> list[str]:
+    match = COMMIT_LINE.search(issue.get("body") or "")
+    if match is None:
+        return []
+    return [
+        commit.strip().lower()
+        for commit in match.group("commits").split(",")
+        if commit.strip()
+    ]
+
+
+def issue_line(issue: dict[str, Any], repository: str) -> str:
+    checked = "x" if issue.get("state") == "CLOSED" else " "
+    line = f"- [{checked}] [{issue['title']}]({issue['url']})"
+    commits = completion_commits(issue)
+    if commits:
+        links = ", ".join(
+            f"[`{commit[:8]}`](https://github.com/{repository}/commit/{commit})"
+            for commit in commits
+        )
+        line += f" — {links}"
+    return line
+
+
+def render_managed_section(
+    snapshot: dict[str, list[dict[str, Any]]], repository: str
+) -> str:
+    open_milestones = {
+        milestone["title"]: milestone
+        for milestone in snapshot["milestones"]
+        if milestone.get("state", "open").lower() == "open"
+    }
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for issue in snapshot["issues"]:
+        milestone = issue.get("milestone")
+        if "roadmap" not in label_names(issue) or not milestone:
+            continue
+        title = milestone["title"]
+        if title not in open_milestones:
+            continue
+        grouped.setdefault(title, []).append(issue)
+
+    lines = [
+        START_MARKER,
+        "## Active releases",
+        "",
+        "Release milestones are shown from earliest to latest. The project board holds",
+        "the live status for each issue.",
+    ]
+    if not grouped:
+        lines.extend(["", "No release milestone is currently active."])
+
+    for title in sorted(grouped, key=release_sort_key):
+        milestone = open_milestones[title]
+        milestone_number = milestone.get("number")
+        heading = title
+        if milestone_number is not None:
+            heading = (
+                f"[{title}](https://github.com/{repository}/milestone/{milestone_number})"
+            )
+        lines.extend(["", f"### {heading}"])
+
+        issues = sorted(grouped[title], key=lambda issue: int(issue["number"]))
+        open_issues = [issue for issue in issues if issue.get("state") != "CLOSED"]
+        completed_issues = [
+            issue for issue in issues if issue.get("state") == "CLOSED"
+        ]
+
+        if open_issues:
+            lines.extend(["", "#### Planned and in progress", ""])
+            lines.extend(issue_line(issue, repository) for issue in open_issues)
+        if completed_issues:
+            lines.extend(["", "#### Completed", ""])
+            lines.extend(issue_line(issue, repository) for issue in completed_issues)
+
+    lines.extend(["", END_MARKER])
+    return "\n".join(lines)
+
+
+def replace_managed_section(document: str, managed_section: str) -> str:
+    if document.count(START_MARKER) != 1 or document.count(END_MARKER) != 1:
+        raise ValueError("Roadmap must contain exactly one managed marker pair.")
+    prefix, remainder = document.split(START_MARKER, 1)
+    _, suffix = remainder.split(END_MARKER, 1)
+    return f"{prefix}{managed_section}{suffix}"
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        snapshot = load_snapshot(arguments.input, arguments.repository)
+        current = arguments.roadmap.read_text(encoding="utf-8")
+        managed = render_managed_section(snapshot, arguments.repository)
+        rendered = replace_managed_section(current, managed)
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    if arguments.check:
+        if rendered != current:
+            print("error: Documentation/ROADMAP.md is out of date", file=sys.stderr)
+            return 1
+        print("Validated the generated roadmap section.")
+        return 0
+
+    if arguments.write:
+        if rendered != current:
+            arguments.roadmap.write_text(rendered, encoding="utf-8")
+            print(f"Updated {arguments.roadmap}.")
+        else:
+            print(f"No changes to {arguments.roadmap}.")
+        return 0
+
+    sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- document the one-way Linear-to-GitHub planning contract and public-copy boundary
- generate the active roadmap section from roadmap-labelled GitHub issues and open milestones
- preserve hand-maintained release gates outside the generated markers
- make README and contributor links release-agnostic
- retain verified completion commits as future release-note input

## Why

Crest planning now spans more than one release. This gives the public repository a stable view of Linear work without copying private planning details or hard-coding the system to 0.5.

## Validation

- `python3 -m unittest Scripts.Tests.test_render_roadmap Scripts.Tests.test_public_source_contract`
- `Scripts/render-roadmap.py --check`
- `Scripts/check-public-source.py`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for public planning synchronization and linked it from the documentation index.
  * Updated contribution and README guidance to reference the Crest Roadmap and release milestones.
* **Roadmap**
  * Replaced the static feature list with an actively synchronized roadmap showing planned, in-progress, and completed work.
  * Added links to relevant project details and completion evidence.
* **Improvements**
  * Added tooling to keep roadmap content current and validate roadmap updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->